### PR TITLE
Fix handling responses with a content warning. Allow copying markdown to clipboard.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ ChatGPT Conversation Downloader is a Firefox* extension to help you save your in
 
 Install the extension and it should add a download button to the nav menu on the left side (see screenshot). Click this and a file will be downloaded in the format "chatgpt_conversation_{datetime}.md".
 
+If the **SHIFT** key is pressed while clicking, the content will be copied to the clipboard instead.
+
 ![screenshot of the context menu](docs/media/button.png)
 
 Sample of the conversation as Markdown:

--- a/src/download-button.js
+++ b/src/download-button.js
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2022 Erik Steinmann
- * 
+ *
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
@@ -24,7 +24,7 @@ if (isChrome) {
     });
 } else {
     browser.storage.local.get("iconType").then(
-        (item) => {            
+        (item) => {
             iconType = item.iconType;
         },
         (error) => {
@@ -49,73 +49,50 @@ setTimeout(() => {
             return `ChatGPT_${formattedDateString}.md`;
         }
     }
-    
+
     // The following method is for a big part written by ChatGPT and so I'm uncertaing regarding the license ...
-    const htmlToMarkdown = (html, lb) => {
-        // Create a new DOMParser to parse the HTML string
-        const parser = new DOMParser();
-        
-        // Parse the HTML string and get the document object
-        const doc = parser.parseFromString(html, "text/html");
-        
+    const htmlToMarkdown = (chatElement, lb) => {
+        const fence = '```';
         // Initialize an empty markdown string
         var markdown = "";
-        
-        // Scrub button nodes.
-        const buttonNodes = doc.querySelectorAll("button");
-        buttonNodes.forEach((node) => {
-            if (node.parentNode) {
-                node.parentNode.removeChild(node);
-            };
-        });
-        
-        // Iterate over all elements in the document
-        doc.body.childNodes.forEach(node => {
+
+        chatElement.forEach(node => {
+            // Skip nodes that contain a content warning.
+            if (typeof node.querySelector !== 'undefined' && node.querySelector('a[href^="https://platform.openai.com/docs/usage-policies" i]')) {
+                return;
+            }
             // If the element is a paragraph, add it to the markdown string with the appropriate formatting
             if (node.nodeName === "P") {
-                markdown += `${lb}${node.textContent}${lb}`;
+                markdown += lb;
+                for (const subNode of node.childNodes) {
+                    switch (subNode.nodeName) {
+                        case 'A':
+                            // FIXME: No handling for special characters like ()[] in the link or link text.
+                            markdown += `[${subNode.textContent}](${subNode?.getAttribute('href') ?? ''})`;
+                            break;
+                        case 'CODE':
+                            // FIXME: No handling for backticks or other special characters.
+                            markdown += `\`${subNode.textContent}\``;
+                            break;
+                        default: markdown += subNode?.textContent ?? '';
+                    }
+                }
+                markdown += lb;
                 return;
             }
-            
+
             // If the element is a preformatted code block, add it to the markdown string with the appropriate formatting
             if (node.nodeName === "PRE") {
-                var lang = null;
-
-                // Find code language (method propsed by ChatGPT)
-                const divElement = node.querySelector(".bg-black");
-                if (divElement)
-                {
-                    const spanElement = divElement.querySelector(".flex > span");
-                    if (spanElement) {
-                        lang = spanElement.textContent;
-                    }
+                const codeEl = node.querySelector('code');
+                if (!codeEl) {
+                    return;
                 }
-                
-                if (lang) {
-                    // Start code block with the language (if found)
-                    markdown += `${lb}\`\`\`` + lang + lb;
+                const lang = (Array.from(codeEl.classList?.values() ?? [])).find(s => s.startsWith('language-'))?.substring(9) ?? '';
 
-                    // Content
-                    if (node.textContent.startsWith(lang)) {
-                        markdown += node.textContent.slice(lang.length);
-                    }
-                    else {
-                        markdown += node.textContent;
-                    }
-                }
-                else {
-                    markdown += `${lb}\`\`\`` + lb;
-
-                    // Content
-                    markdown += node.textContent;
-                }
-
-                // End code block
-                markdown += `${lb}\`\`\`${lb}`;
-                
+                markdown += `${lb}${fence}${lang}${lb}${codeEl.textContent}${lb}${fence}${lb}`;
                 return;
             }
-            
+
             // If the element is an unordered list, add its items to the markdown string with the appropriate formatting
             if (node.nodeName === "UL") {
                 markdown += lb;
@@ -124,7 +101,7 @@ setTimeout(() => {
                 });
                 return;
             }
-            
+
             // If the element is an ordered list, add its items to the markdown string with the appropriate formatting
             if (node.nodeName === "OL") {
                 markdown += lb;
@@ -155,82 +132,51 @@ setTimeout(() => {
                 });
                 return;
             }
-            
+
             // Fall back on unprocessed textContent if other tag is encountered.
             markdown += `${lb}${node.textContent}${lb}`;
         });
-        
+
         // Return the resulting markdown string
         return markdown;
     }
-    
-    const download = () => {
+
+    const download = (event) => {
         // Determine line break character based on platform. Default to LF on non-Windows platforms.
         var lineBreak = "\n";
         if(navigator.userAgent.indexOf("Windows") != -1) {
             // CLRF on Windows
             lineBreak = "\r\n";
         }
-        
-        // Extract the name that OpenAI has assigned to the selected conversation
-        var conversationName = null;
 
-        // XPath is also written by ChatGPT :-)
-        const conversationNameNode = document.evaluate(
-            "//div[starts-with(@class,'flex-col flex-1 overflow-y-auto border-b border-white/20 -mr-2')]//a[starts-with(@class,'flex py-3 px-3 items-center gap-3 relative rounded-md cursor-pointer break-all pr-14 bg-gray-800 hover:bg-gray-800 group')]/div[@class='flex-1 text-ellipsis max-h-5 overflow-hidden break-all relative']/text()",
-            document,
-            null,
-            XPathResult.ANY_TYPE,
-            null
-        );
-        
-        let matchConversationName = conversationNameNode.iterateNext();
-        if (matchConversationName) {
-            conversationName = matchConversationName.nodeValue;
-        }        
-        
-        /* 
-            XPath is (partially) based on suggestions by ChatGPT.
-            1. Find divs under <main> of class text-base
-            2. Within these text-base div find the actual content:
-                - Text nodes
-                - <p> elements
-                - <pre> elements (code blocks)
-        */
-        const matches = document.evaluate("//main//div[contains(@class, 'text-base')]//div[not(*) or p or pre]", document, null, XPathResult.ORDERED_NODE_ITERATOR_TYPE, null);                                
-        var match = matches.iterateNext();
-        
-        var conversation = "";
+        // Extract the name that OpenAI has assigned to the selected conversation
+        const conversationName = document?.querySelector('title')?.innerText ?? 'Unknown';
+
+        var conversation = `# ${conversationName}${lineBreak}${lineBreak}`;
         var counter = 0;
 
-        if (conversationName)
-            conversation += "# " + conversationName + lineBreak + lineBreak;
+        for (const matchEl of document.querySelectorAll('.group .text-base .items-start.whitespace-pre-wrap')) {
+            const match = matchEl.firstChild?.children?.length > 0 ? matchEl?.firstChild?.childNodes : matchEl?.childNodes;
 
-        while (match) {
-            // Skip empty node in <main>.
-            if ((match.textContent === "") ||
-                (match.textContent === null)) {
-                match = matches.iterateNext();
+            if (!match) {
                 continue;
             }
-            // Assuming the first matched node is always the users question ...        
-            var actor = "You";
-            var content = lineBreak + match.textContent + lineBreak;
-            if ((counter % 2) === 1) {
-                // ChatGPT answers
-                actor = "ChatGPT";
-                content = htmlToMarkdown(match.innerHTML, lineBreak);
-            }
-            
-            conversation += `### ${actor}` + content + lineBreak;
-            
-            match = matches.iterateNext();
+            const isUser = counter % 2 === 0;
+            conversation += `### ${isUser ? "You" : "ChatGPT"}${
+                isUser
+                    ? `${lineBreak}${match.item(0)?.textContent ?? ''}${lineBreak}`
+                    : htmlToMarkdown(match, lineBreak)
+            }${lineBreak}`;
             counter++;
         }
-        
+
         if (counter > 0) {
             console.log("Your conversation with ChatGPT:" + lineBreak + lineBreak + conversation);
-            
+
+            if (event.shiftKey) {
+                navigator.clipboard.writeText(conversation);
+                return;
+            }
             // Create a temporary <a> element to initiate the download.
             const url = URL.createObjectURL(new Blob([conversation], { type: "text/markdown" }));
             const link = document.createElement('a');
@@ -241,25 +187,19 @@ setTimeout(() => {
             alert("Sorry, but there doesn't seem to be any conversation on this tab.");
         }
     };
-    
-    const buttonExists = () => {        
+
+    const buttonExists = () => {
         // Check for probe class to exist on element within <nav> block.
-        const xpath = "//nav//*[contains(@class, 'convdown-probe')]";
-        
-        // Evaluate the XPath expression
-        var result = document.evaluate(xpath, document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null);
-        
-        // Return true if an element was found, or false if not
-        return result.singleNodeValue !== null;
+        return !!document.querySelector('nav a.convdown-probe');
     };
-    
+
     // Check if download button was already added before altering document. Sometimes ChatGPT appears to 'hang' and clicking on individual chats keeps adding download buttons. The following check should prevent hat.
     if (buttonExists()) {
         // Already added the button. return.
         console.error("ChatGPT ConvDown: Download button already added to the document!");
         return;
     }
-    
+
     // Create the icon element for the download button.
     var iconElement = null;
     if (iconType === "bootstrap") {
@@ -267,15 +207,15 @@ setTimeout(() => {
         const ns = "http://www.w3.org/2000/svg";
         iconElement = document.createElementNS(ns, "svg");
         iconElement.setAttribute("fill", "currentColor");
-        iconElement.setAttribute("viewBox", "0 0 16 16");        
+        iconElement.setAttribute("viewBox", "0 0 16 16");
         path1 = iconElement.appendChild(document.createElementNS(ns, "path"));
         path1.setAttribute("d", "M.5 9.9a.5.5 0 0 1 .5.5v2.5a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1v-2.5a.5.5 0 0 1 1 0v2.5a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2v-2.5a.5.5 0 0 1 .5-.5z");
         path2 = iconElement.appendChild(document.createElementNS(ns, "path"));
-        path2.setAttribute("d", "M7.646 11.854a.5.5 0 0 0 .708 0l3-3a.5.5 0 0 0-.708-.708L8.5 10.293V1.5a.5.5 0 0 0-1 0v8.793L5.354 8.146a.5.5 0 1 0-.708.708l3 3z");        
+        path2.setAttribute("d", "M7.646 11.854a.5.5 0 0 0 .708 0l3-3a.5.5 0 0 0-.708-.708L8.5 10.293V1.5a.5.5 0 0 0-1 0v8.793L5.354 8.146a.5.5 0 1 0-.708.708l3 3z");
     } else {
         // Green arrow PNG image.
         iconElement = document.createElement("img");
-        iconElement.src = browser.runtime.getURL("media/download.png");        
+        iconElement.src = browser.runtime.getURL("media/download.png");
     }
     iconElement.classList.add("w-4", "h-4");
     iconElement.width = "1em";
@@ -287,10 +227,8 @@ setTimeout(() => {
     aElement.appendChild(iconElement);
     var textNode = document.createTextNode("Download");
     aElement.appendChild(textNode);
-    aElement.addEventListener('click', (event) => {
-        download();
-    });
-    
+    aElement.addEventListener('click', download);
+
     // Get the <nav> element and append <a> to it.
     const nav = document.querySelector("nav");
     nav.appendChild(aElement);

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -15,6 +15,7 @@
         "page": "options.html"
     },
     "permissions": [
+        "clipboardWrite",
         "storage",
         "webNavigation",
         "*://chat.openai.com/chat/*"


### PR DESCRIPTION
**Note**: Right now, this is very lightly tested so even if you like the changes it probably would be a good idea to wait a bit and test more just to make sure my changes didn't cause any issues.

Currently, there's a problem where ChatGPT responses containing a content warning will be ignored. This causes the whole conversation to go out of sync and the offending response also is not saved. I believe there may be some other cases which cause this behavior. Though I don't understand XPATH very well, it looks like something like a response containing a link would also have the same problem since the query is `//main//div[contains(@class, 'text-base')]//div[not(*) or p or pre]`. If I'm reading it correctly, it will only allow `div`s with no child elements (so just text inside) or `div`s that have `p` or `pre`, but an `a` in there would cause it not to match. 

I rewrote the XPATH queries to use CSS selectors and simplified some of the code. I don't know if you had some really compelling reason to use it, but I think a lot more people understand/use selectors and they're generally a lot simpler to work with. (It is true that XPATH does allow some functionality you can't easily achieve with selectors, but in this case I don't think you actually need it.)

The other thing I added was allowing the user to copy the generated markdown to clipboard instead of downloading it. If the user holds SHIFT while clicking the download button, it'll be copied to clipboard instead of downloaded. This did require adding `clipboardWrite` to the manifest permissions list.

***

**edit**: These changes now also allow preserving inline code blocks and links with titles (in a naive way that that doesn't handle special characters — but that should be a rare problem). Example:

If a ChatGPT response part looks like:

```html
<p>This should display as: <a href="https://en.wikipedia.org/wiki/Great_Barrier_Reef" target="_new">Great Barrier Reef</a></p>
```

it will be converted to:

```markdown
This should display as: [Great Barrier Reef](https://en.wikipedia.org/wiki/Great_Barrier_Reef)
```

If a ChatGPT response part looks like:

```html
<p>To use this approach with multiple objects, you would need to create a separate <code>ShaderMaterial</code> and set the</p>
```

it will be converted to:

```markdown
To use this approach with multiple objects, you would need to create a separate `ShaderMaterial` and set the
```